### PR TITLE
Bug fix for crasher in `test_diff_commonOverlap` when running tests w…

### DIFF
--- a/DiffMatchPatchCFUtilities.c
+++ b/DiffMatchPatchCFUtilities.c
@@ -249,7 +249,7 @@ CFIndex diff_commonOverlap(CFStringRef text1, CFStringRef text2) {
 
   CFIndex text_length = MIN(text1_length, text2_length);
   // Quick check for the worst case.
-  if (text1_trunc == text2_trunc) {
+  if (CFStringCompare(text1_trunc, text2_trunc, 0) == kCFCompareEqualTo) {
     common_overlap = text_length;
   } else {
     // Start by looking for a single character match


### PR DESCRIPTION
…ith Swift Package manager.

A litte context: I'm creating a SPM package and I'm using SPM to build the objective-C part while translating the tests to swift. While doing so I found that
```
  XCTAssertEqual((NSUInteger)3, [dmp diff_commonOverlapOfFirstString:@"abc" andSecondString:@"abcd"], @"Detect any suffix/prefix overlap. Whole case.");
```
crashes with
```
fatal error: subscript: subrange start precedes String start
```

It looks like this is actually a genuine bug in `diff_commonOverlap` where it does a pointer comparison instead of a string comparison.